### PR TITLE
Remove version from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,8 +3,6 @@
 namespace: splunk
 # the designation of this specific collection
 name: es
-# semantic versioning compliant version designation
-version: 0.0.6
 # a list of the collection's content authors: 'Full Name <email> (http://site) @nicks:irc/im/site#channel'
 authors:
   - 'Ansible Security Automation Team (https://github.com/ansible-security)'


### PR DESCRIPTION
This is no longer needed, as version strings are generated dynamically
based on git sha1 info.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>