### PR TITLE
README: Add Communication section with Forum information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and provide feedback about.
 
 * Join the Ansible forum:
   * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  * [Posts tagged with 'splunk-es'](https://forum.ansible.com/tag/splunk-es): subscribe to participate in collection-related conversations.
+  * [Posts tagged with 'security'](https://forum.ansible.com/tag/security): subscribe to participate in collection-related conversations.
   * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
   * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ This Collection is meant for distribution through
 [Ansible](https://github.com/ansible/ansible) users to utilize, contribute to,
 and provide feedback about.
 
+## Communication
+
+* Join the Ansible forum:
+  * [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  * [Posts tagged with 'splunk-es'](https://forum.ansible.com/tag/splunk-es): subscribe to participate in collection-related conversations.
+  * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+  * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events.
+
+* The Ansible [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): used to announce releases and important changes.
+
+For more information about communication, see the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 <!--start requires_ansible-->
 ## Ansible version compatibility
 

--- a/changelogs/fragments/0-readme.yml
+++ b/changelogs/fragments/0-readme.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - README.md - Add Communication section with Forum information.


### PR DESCRIPTION
##### SUMMARY
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README. Similar PRs are being raised across all included collections under the ansible-collection org for now.

- I've created the `splunk-es` forum tag. It's not a must for maintainers to be subscribed but please consider it
- If you have other forum tags related to the collection, please update corresponding lines by suggesting changes to the PR.
- Presence in the forum will soon likely become a part of the Collection inclusion requirements.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
README.md
