### PR TITLE
Change deprecated _include to support newer versions of Ansible

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,10 @@
 ---
 
 profile: production
+
+exclude_paths:
+  - plugins/modules/adaptive_response_notable_event.py
+  - plugins/modules/correlation_search.py
+  - plugins/modules/correlation_search_info.py
+  - plugins/modules/data_input_monitor.py
+  - plugins/modules/data_input_network.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/ansible-network/collection_prep
-    rev: 1.1.1
+    rev: da78082ea59b03ad16cd7dbee267f53e8ff50bb5
     hooks:
       # - id: autoversion # removed as being handled by GHA push and release drafter
       - id: update-docs

--- a/README.md
+++ b/README.md
@@ -38,10 +38,8 @@ You can join us on [#network:ansible.com](https://matrix.to/#/#network:ansible.c
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15.0**.
+This collection has been tested against the following Ansible versions: **>=2.15.0**.
 
-For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
-fully qualified collection name (for example, `cisco.ios.ios`).
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/changelogs/fragments/fix_lint_errors.yaml
+++ b/changelogs/fragments/fix_lint_errors.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fixed ansible-lint errors by adding missing task names in integration tests.
+  - Fixed deprecated module alternatives to use fully qualified collection names (FQCN).
+  - Added sanity test ignore file for Ansible 2.20 to handle pylint errors in deprecated modules.

--- a/docs/splunk.es.adaptive_response_notable_event_module.rst
+++ b/docs/splunk.es.adaptive_response_notable_event_module.rst
@@ -18,7 +18,7 @@ DEPRECATED
 ----------
 :Removed in collection release after 2024-09-01
 :Why: Newer and updated modules released with more functionality.
-:Alternative: splunk_adaptive_response_notable_events
+:Alternative: splunk.es.splunk_adaptive_response_notable_events
 
 
 

--- a/docs/splunk.es.correlation_search_module.rst
+++ b/docs/splunk.es.correlation_search_module.rst
@@ -18,7 +18,7 @@ DEPRECATED
 ----------
 :Removed in collection release after 2024-09-01
 :Why: Newer and updated modules released with more functionality.
-:Alternative: splunk_correlation_searches
+:Alternative: splunk.es.splunk_correlation_searches
 
 
 

--- a/docs/splunk.es.data_input_monitor_module.rst
+++ b/docs/splunk.es.data_input_monitor_module.rst
@@ -18,7 +18,7 @@ DEPRECATED
 ----------
 :Removed in collection release after 2024-09-01
 :Why: Newer and updated modules released with more functionality.
-:Alternative: splunk_data_inputs_monitor
+:Alternative: splunk.es.splunk_data_inputs_monitor
 
 
 

--- a/docs/splunk.es.data_input_network_module.rst
+++ b/docs/splunk.es.data_input_network_module.rst
@@ -18,7 +18,7 @@ DEPRECATED
 ----------
 :Removed in collection release after 2024-09-01
 :Why: Newer and updated modules released with more functionality.
-:Alternative: splunk_data_inputs_network
+:Alternative: splunk.es.splunk_data_inputs_network
 
 
 

--- a/plugins/modules/adaptive_response_notable_event.py
+++ b/plugins/modules/adaptive_response_notable_event.py
@@ -189,8 +189,8 @@ EXAMPLES = """
 
 import json
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.urllib.parse import quote_plus, urlencode
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 

--- a/plugins/modules/adaptive_response_notable_event.py
+++ b/plugins/modules/adaptive_response_notable_event.py
@@ -21,7 +21,7 @@ description:
     with a correlation search
 version_added: "1.0.0"
 deprecated:
-  alternative: splunk_adaptive_response_notable_events
+  alternative: splunk.es.splunk_adaptive_response_notable_events
   why: Newer and updated modules released with more functionality.
   removed_at_date: '2024-09-01'
 options:
@@ -189,7 +189,7 @@ EXAMPLES = """
 
 import json
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import quote_plus, urlencode
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils

--- a/plugins/modules/correlation_search.py
+++ b/plugins/modules/correlation_search.py
@@ -175,8 +175,8 @@ EXAMPLES = """
     state: "present"
 """
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.parse import quote_plus, urlencode
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils

--- a/plugins/modules/correlation_search.py
+++ b/plugins/modules/correlation_search.py
@@ -19,7 +19,7 @@ description:
   - This module allows for creation, deletion, and modification of Splunk Enterprise Security Correlation Searches
 version_added: "1.0.0"
 deprecated:
-  alternative: splunk_correlation_searches
+  alternative: splunk.es.splunk_correlation_searches
   why: Newer and updated modules released with more functionality.
   removed_at_date: '2024-09-01'
 options:
@@ -175,7 +175,7 @@ EXAMPLES = """
     state: "present"
 """
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.parse import quote_plus, urlencode

--- a/plugins/modules/data_input_monitor.py
+++ b/plugins/modules/data_input_monitor.py
@@ -140,8 +140,8 @@ EXAMPLES = """
     recursive: true
 """
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 

--- a/plugins/modules/data_input_monitor.py
+++ b/plugins/modules/data_input_monitor.py
@@ -19,7 +19,7 @@ description:
   - This module allows for addition or deletion of File and Directory Monitor Data Inputs in Splunk.
 version_added: "1.0.0"
 deprecated:
-  alternative: splunk_data_inputs_monitor
+  alternative: splunk.es.splunk_data_inputs_monitor
   why: Newer and updated modules released with more functionality.
   removed_at_date: '2024-09-01'
 options:
@@ -140,7 +140,7 @@ EXAMPLES = """
     recursive: true
 """
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils

--- a/plugins/modules/data_input_network.py
+++ b/plugins/modules/data_input_network.py
@@ -141,8 +141,8 @@ EXAMPLES = """
 """
 
 
-from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 
 from ansible_collections.splunk.es.plugins.module_utils.splunk import SplunkRequest

--- a/plugins/modules/data_input_network.py
+++ b/plugins/modules/data_input_network.py
@@ -19,7 +19,7 @@ description:
   - This module allows for addition or deletion of TCP and UDP Data Inputs in Splunk.
 version_added: "1.0.0"
 deprecated:
-  alternative: splunk_data_inputs_network
+  alternative: splunk.es.splunk_data_inputs_network
   why: Newer and updated modules released with more functionality.
   removed_at_date: '2024-09-01'
 options:
@@ -141,7 +141,7 @@ EXAMPLES = """
 """
 
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 

--- a/plugins/modules/splunk_data_inputs_monitor.py
+++ b/plugins/modules/splunk_data_inputs_monitor.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+"""Splunk Data Inputs Monitor resource module."""
 
 # Copyright 2022 Red Hat
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -7,7 +8,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-__metaclass__ = type
+__metaclass__ = type  # pylint: disable=invalid-name
 
 DOCUMENTATION = """
 ---

--- a/tests/integration/targets/splunk_adaptive_response_notable_events/tasks/main.yaml
+++ b/tests/integration/targets/splunk_adaptive_response_notable_events/tasks/main.yaml
@@ -1,7 +1,9 @@
 ---
-- ansible.builtin._include: cli.yaml
+- name: Include CLI tasks
+  ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- ansible.builtin._include: redirection.yaml
+- name: Include redirection tasks
+  ansible.builtin.include_tasks: redirection.yaml
   when: ansible_version.full is version('2.10.0', '>=')

--- a/tests/integration/targets/splunk_data_inputs_monitor/defaults/main.yaml
+++ b/tests/integration/targets/splunk_data_inputs_monitor/defaults/main.yaml
@@ -1,2 +1,4 @@
 ---
 testcase: "*"
+ansible_user: admin
+ansible_httpapi_pass: Splunk10vin!

--- a/tests/integration/targets/splunk_data_inputs_monitor/tasks/main.yaml
+++ b/tests/integration/targets/splunk_data_inputs_monitor/tasks/main.yaml
@@ -1,7 +1,9 @@
 ---
-- ansible.builtin._include: cli.yaml
+- name: Include CLI tasks
+  ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- ansible.builtin._include: redirection.yaml
+- name: Include redirection tasks
+  ansible.builtin.include_tasks: redirection.yaml
   when: ansible_version.full is version('2.10.0', '>=')

--- a/tests/integration/targets/splunk_data_inputs_network/tasks/main.yaml
+++ b/tests/integration/targets/splunk_data_inputs_network/tasks/main.yaml
@@ -1,7 +1,9 @@
 ---
-- ansible.builtin._include: cli.yaml
+- name: Include CLI tasks
+  ansible.builtin.include_tasks: cli.yaml
   tags:
     - cli
 
-- ansible.builtin._include: redirection.yaml
+- name: Include redirection tasks
+  ansible.builtin.include_tasks: redirection.yaml
   when: ansible_version.full is version('2.10.0', '>=')

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -24,7 +24,7 @@ __metaclass__ = type
 import os
 
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.parsing.dataloader import DataLoader
 
 

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -28,8 +28,7 @@ import sys
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils.six import PY3
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.splunk.es.tests.unit.compat import unittest
 
@@ -42,11 +41,8 @@ def swap_stdin_and_argv(stdin_data="", argv_data=tuple()):
     real_stdin = sys.stdin
     real_argv = sys.argv
 
-    if PY3:
-        fake_stream = StringIO(stdin_data)
-        fake_stream.buffer = BytesIO(to_bytes(stdin_data))
-    else:
-        fake_stream = BytesIO(to_bytes(stdin_data))
+    fake_stream = StringIO(stdin_data)
+    fake_stream.buffer = BytesIO(to_bytes(stdin_data))
 
     try:
         sys.stdin = fake_stream
@@ -65,10 +61,7 @@ def swap_stdout():
     """
     old_stdout = sys.stdout
 
-    if PY3:
-        fake_stream = StringIO()
-    else:
-        fake_stream = BytesIO()
+    fake_stream = StringIO()
 
     try:
         sys.stdout = fake_stream

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.parsing.vault import VaultSecret
 
 

--- a/tests/unit/mock/yaml_helper.py
+++ b/tests/unit/mock/yaml_helper.py
@@ -6,7 +6,6 @@ import io
 
 import yaml
 
-from ansible.module_utils.six import PY3
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.loader import AnsibleLoader
 
@@ -22,17 +21,11 @@ class YamlTestUtils(object):
 
     def _dump_stream(self, obj, stream, dumper=None):
         """Dump to a py2-unicode or py3-string stream."""
-        if PY3:
-            return yaml.dump(obj, stream, Dumper=dumper)
-        else:
-            return yaml.dump(obj, stream, Dumper=dumper, encoding=None)
+        return yaml.dump(obj, stream, Dumper=dumper)
 
     def _dump_string(self, obj, dumper=None):
         """Dump to a py2-unicode or py3-string"""
-        if PY3:
-            return yaml.dump(obj, Dumper=dumper)
-        else:
-            return yaml.dump(obj, Dumper=dumper, encoding=None)
+        return yaml.dump(obj, Dumper=dumper)
 
     def _dump_load_cycle(self, obj):
         # Each pass though a dump or load revs the 'generation'
@@ -95,30 +88,16 @@ class YamlTestUtils(object):
         stream_obj_from_stream = io.StringIO()
         stream_obj_from_string = io.StringIO()
 
-        if PY3:
-            yaml.dump(
-                obj_from_stream,
-                stream_obj_from_stream,
-                Dumper=AnsibleDumper,
-            )
-            yaml.dump(
-                obj_from_stream,
-                stream_obj_from_string,
-                Dumper=AnsibleDumper,
-            )
-        else:
-            yaml.dump(
-                obj_from_stream,
-                stream_obj_from_stream,
-                Dumper=AnsibleDumper,
-                encoding=None,
-            )
-            yaml.dump(
-                obj_from_stream,
-                stream_obj_from_string,
-                Dumper=AnsibleDumper,
-                encoding=None,
-            )
+        yaml.dump(
+            obj_from_stream,
+            stream_obj_from_stream,
+            Dumper=AnsibleDumper,
+        )
+        yaml.dump(
+            obj_from_stream,
+            stream_obj_from_string,
+            Dumper=AnsibleDumper,
+        )
 
         yaml_string_stream_obj_from_stream = stream_obj_from_stream.getvalue()
         yaml_string_stream_obj_from_string = stream_obj_from_string.getvalue()
@@ -126,26 +105,14 @@ class YamlTestUtils(object):
         stream_obj_from_stream.seek(0)
         stream_obj_from_string.seek(0)
 
-        if PY3:
-            yaml_string_obj_from_stream = yaml.dump(
-                obj_from_stream,
-                Dumper=AnsibleDumper,
-            )
-            yaml_string_obj_from_string = yaml.dump(
-                obj_from_string,
-                Dumper=AnsibleDumper,
-            )
-        else:
-            yaml_string_obj_from_stream = yaml.dump(
-                obj_from_stream,
-                Dumper=AnsibleDumper,
-                encoding=None,
-            )
-            yaml_string_obj_from_string = yaml.dump(
-                obj_from_string,
-                Dumper=AnsibleDumper,
-                encoding=None,
-            )
+        yaml_string_obj_from_stream = yaml.dump(
+            obj_from_stream,
+            Dumper=AnsibleDumper,
+        )
+        yaml_string_obj_from_string = yaml.dump(
+            obj_from_string,
+            Dumper=AnsibleDumper,
+        )
 
         assert yaml_string == yaml_string_obj_from_stream
         assert yaml_string == yaml_string_obj_from_stream == yaml_string_obj_from_string

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -9,14 +9,13 @@ import json
 
 import pytest
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:

--- a/tests/unit/modules/conftest.py
+++ b/tests/unit/modules/conftest.py
@@ -9,8 +9,8 @@ import json
 
 import pytest
 
-from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @pytest.fixture

--- a/tests/unit/modules/utils.py
+++ b/tests/unit/modules/utils.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 import json
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.splunk.es.tests.unit.compat import unittest
 from ansible_collections.splunk.es.tests.unit.compat.mock import patch

--- a/tests/unit/plugins/action/test_es_adaptive_response_notable_events.py
+++ b/tests/unit/plugins/action/test_es_adaptive_response_notable_events.py
@@ -21,12 +21,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.six import PY2
-
-
 builtin_import = "builtins.__import__"
-if PY2:
-    builtin_import = "__builtin__.__import__"
 
 import tempfile
 

--- a/tests/unit/plugins/action/test_es_correlation_searches.py
+++ b/tests/unit/plugins/action/test_es_correlation_searches.py
@@ -21,12 +21,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.six import PY2
-
-
 builtin_import = "builtins.__import__"
-if PY2:
-    builtin_import = "__builtin__.__import__"
 
 import tempfile
 

--- a/tests/unit/plugins/action/test_es_data_inputs_monitors.py
+++ b/tests/unit/plugins/action/test_es_data_inputs_monitors.py
@@ -21,12 +21,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.six import PY2
-
-
 builtin_import = "builtins.__import__"
-if PY2:
-    builtin_import = "__builtin__.__import__"
 
 import tempfile
 

--- a/tests/unit/plugins/action/test_es_data_inputs_network.py
+++ b/tests/unit/plugins/action/test_es_data_inputs_network.py
@@ -21,12 +21,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible.module_utils.six import PY2
-
-
 builtin_import = "builtins.__import__"
-if PY2:
-    builtin_import = "__builtin__.__import__"
 
 import copy
 import tempfile

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -9,14 +9,13 @@ import json
 
 import pytest
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -9,8 +9,8 @@ import json
 
 import pytest
 
-from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @pytest.fixture

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 import json
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.splunk.es.tests.unit.compat import unittest
 from ansible_collections.splunk.es.tests.unit.compat.mock import patch


### PR DESCRIPTION
##### SUMMARY
- Change deprecated _include to support newer versions of Ansible

##### ISSUE TYPE
- Ansible Version Compatability

##### COMPONENT NAME
- ansible.builtin.include_tasks

##### ADDITIONAL INFORMATION
Integration tests failing on 
```
ERROR! this task 'ansible.builtin._include' has extra params, which is only allowed in the following modules: include_tasks, include_role, win_command, import_tasks, add_host, raw, win_shell, meta, group_by, shell, import_role, set_fact, script, command, include_vars
```