### PR TITLE
Add support for limit query param and refactor code

### DIFF
--- a/changelogs/fragments/add_limit_parameter.yaml
+++ b/changelogs/fragments/add_limit_parameter.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added ``limit`` parameter to splunk_finding_info, splunk_investigation_info, and splunk_response_plan_info modules to control the maximum number of results returned.

--- a/docs/splunk.es.splunk_finding_info_module.rst
+++ b/docs/splunk.es.splunk_finding_info_module.rst
@@ -134,6 +134,23 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>limit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Maximum number of findings to return.</div>
+                        <div>If not specified, all matching findings are returned.</div>
+                        <div>Use this to limit large result sets.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ref_id</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -221,6 +238,12 @@ Examples
       splunk.es.splunk_finding_info:
         earliest: "-30d"
       register: all_findings
+
+    - name: Query findings with a limit on results
+      splunk.es.splunk_finding_info:
+        earliest: "-7d"
+        limit: 100
+      register: limited_findings
 
     - name: Query findings from a specific time range (ISO 8601)
       splunk.es.splunk_finding_info:

--- a/docs/splunk.es.splunk_investigation_info_module.rst
+++ b/docs/splunk.es.splunk_investigation_info_module.rst
@@ -144,6 +144,23 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>limit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Maximum number of investigations to return.</div>
+                        <div>If not specified, all matching investigations are returned.</div>
+                        <div>Use this to limit large result sets.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -212,6 +229,12 @@ Examples
       splunk.es.splunk_investigation_info:
         create_time_min: "-30d"
       register: all_investigations
+
+    - name: Query investigations with a limit on results
+      splunk.es.splunk_investigation_info:
+        create_time_min: "-7d"
+        limit: 50
+      register: limited_investigations
 
     - name: Query investigations from a specific time range (ISO 8601)
       splunk.es.splunk_investigation_info:

--- a/docs/splunk.es.splunk_response_plan_info_module.rst
+++ b/docs/splunk.es.splunk_response_plan_info_module.rst
@@ -91,6 +91,23 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>limit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Maximum number of response plans to return.</div>
+                        <div>If not specified, returns all matching response plans.</div>
+                        <div>Useful for limiting results when querying large numbers of response plans.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/action/splunk_response_plan_info.py
+++ b/plugins/action/splunk_response_plan_info.py
@@ -169,6 +169,20 @@ class ActionModule(ActionBase):
         """
         return _build_response_plan_api_path(self.api_namespace, self.api_user, self.api_app)
 
+    def _build_query_params(self) -> dict[str, Any] | None:
+        """Build query params dict with limit if provided.
+
+        Returns:
+            Dict with query params if any are set, None otherwise.
+        """
+        query_params: dict[str, Any] = {}
+
+        limit = self._task.args.get("limit")
+        if limit:
+            query_params["limit"] = limit
+
+        return query_params if query_params else None
+
     def get_all_response_plans(self, conn_request: SplunkRequest) -> list[dict[str, Any]]:
         """Get all response plans from the API.
 
@@ -180,7 +194,10 @@ class ActionModule(ActionBase):
         """
         display.vv("splunk_response_plan_info: fetching all response plans")
 
-        response = conn_request.get_by_path(self.api_object)
+        query_params = self._build_query_params()
+        display.vv(f"splunk_response_plan_info: query_params={query_params}")
+
+        response = conn_request.get_by_path(self.api_object, query_params=query_params)
 
         response_plans = []
         if response and "items" in response:
@@ -250,6 +267,7 @@ class ActionModule(ActionBase):
             connection=conn,
             not_rest_data_keys=[
                 "name",
+                "limit",
                 "api_namespace",
                 "api_user",
                 "api_app",

--- a/plugins/module_utils/investigation.py
+++ b/plugins/module_utils/investigation.py
@@ -7,67 +7,29 @@
 
 from typing import Any, Optional
 
-from ansible_collections.splunk.es.plugins.module_utils.finding import (
+from ansible_collections.splunk.es.plugins.module_utils.splunk_utils import (
+    DEFAULT_API_APP,
+    DEFAULT_API_NAMESPACE,
+    DEFAULT_API_USER,
     DISPOSITION_FROM_API,
-    DISPOSITION_TO_API,
     STATUS_FROM_API,
-    STATUS_TO_API,
 )
 
 
-# Default API path components
-DEFAULT_API_NAMESPACE = "servicesNS"
-DEFAULT_API_USER = "nobody"
-DEFAULT_API_APP = "missioncontrol"
-
-# API path for investigations API
+# API path for investigations API (uses missioncontrol app)
 INVESTIGATION_API_PATH = (
     f"{DEFAULT_API_NAMESPACE}/{DEFAULT_API_USER}/{DEFAULT_API_APP}/public/v2/investigations"
 )
 
-# Fields that can be updated via the main update endpoint (name cannot be updated)
-UPDATABLE_FIELDS = [
-    "description",
-    "status",
-    "disposition",
-    "owner",
-    "urgency",
-    "sensitivity",
-]
-
-# finding_ids requires a separate API endpoint
-FINDING_IDS_FIELD = "finding_ids"
-
-# Urgency choices
-URGENCY_CHOICES = [
-    "informational",
-    "low",
-    "medium",
-    "high",
-    "critical",
-    "unknown",
-]
-
-# Sensitivity choices (lowercase for user input)
-SENSITIVITY_CHOICES = [
-    "white",
-    "green",
-    "amber",
-    "red",
-    "unassigned",
-]
-
-# Sensitivity mapping: module value (lowercase) -> API value (capitalized)
-SENSITIVITY_TO_API = {
-    "white": "White",
-    "green": "Green",
-    "amber": "Amber",
-    "red": "Red",
-    "unassigned": "Unassigned",
+# Sensitivity mapping: API value (capitalized) -> module value (lowercase)
+# Used by map_investigation_from_api to convert API responses
+SENSITIVITY_FROM_API = {
+    "White": "white",
+    "Green": "green",
+    "Amber": "amber",
+    "Red": "red",
+    "Unassigned": "unassigned",
 }
-
-# Sensitivity mapping: API value -> module value
-SENSITIVITY_FROM_API = {v: k for k, v in SENSITIVITY_TO_API.items()}
 
 
 def build_investigation_api_path(
@@ -86,46 +48,6 @@ def build_investigation_api_path(
         The complete investigations API path.
     """
     return f"{namespace}/{user}/{app}/public/v2/investigations"
-
-
-def build_investigation_update_path(
-    ref_id: str,
-    namespace: str = DEFAULT_API_NAMESPACE,
-    user: str = DEFAULT_API_USER,
-    app: str = DEFAULT_API_APP,
-) -> str:
-    """Build the investigations update API path.
-
-    Args:
-        ref_id: The investigation reference ID.
-        namespace: The namespace portion of the path. Defaults to 'servicesNS'.
-        user: The user portion of the path. Defaults to 'nobody'.
-        app: The app portion of the path. Defaults to 'missioncontrol'.
-
-    Returns:
-        The investigations update API path with ref_id.
-    """
-    return f"{build_investigation_api_path(namespace, user, app)}/{ref_id}"
-
-
-def build_investigation_findings_path(
-    ref_id: str,
-    namespace: str = DEFAULT_API_NAMESPACE,
-    user: str = DEFAULT_API_USER,
-    app: str = DEFAULT_API_APP,
-) -> str:
-    """Build the API path for adding findings to an investigation.
-
-    Args:
-        ref_id: The investigation reference ID.
-        namespace: The namespace portion of the path. Defaults to 'servicesNS'.
-        user: The user portion of the path. Defaults to 'nobody'.
-        app: The app portion of the path. Defaults to 'missioncontrol'.
-
-    Returns:
-        The API path for adding findings to the investigation.
-    """
-    return f"{build_investigation_update_path(ref_id, namespace, user, app)}/findings"
 
 
 def _extract_finding_ids(config: dict[str, Any]) -> Optional[list[str]]:
@@ -210,71 +132,5 @@ def map_investigation_from_api(config: dict[str, Any]) -> dict[str, Any]:
     _convert_api_enum_value(res, "status", STATUS_FROM_API, stringify_key=True)
     _convert_api_enum_value(res, "disposition", DISPOSITION_FROM_API, stringify_key=True)
     _convert_api_enum_value(res, "sensitivity", SENSITIVITY_FROM_API)
-
-    return res
-
-
-def map_investigation_to_api(investigation: dict[str, Any]) -> dict[str, Any]:
-    """Convert module params to API payload format.
-
-    Args:
-        investigation: The investigation parameters dictionary.
-
-    Returns:
-        Dictionary formatted for the Splunk investigations API.
-    """
-    res = investigation.copy()
-
-    # Handle status conversion to API numeric value
-    if "status" in res and res["status"]:
-        res["status"] = STATUS_TO_API.get(res["status"], res["status"])
-
-    # Handle disposition conversion to API format
-    if "disposition" in res and res["disposition"]:
-        res["disposition"] = DISPOSITION_TO_API.get(
-            res["disposition"].lower(),
-            res["disposition"],
-        )
-
-    # Handle sensitivity conversion to API format (capitalized)
-    if "sensitivity" in res and res["sensitivity"]:
-        res["sensitivity"] = SENSITIVITY_TO_API.get(
-            res["sensitivity"].lower(),
-            res["sensitivity"],
-        )
-
-    return res
-
-
-def map_investigation_update_to_api(investigation: dict[str, Any]) -> dict[str, Any]:
-    """Convert module params to API payload format for updating investigations.
-
-    Only includes fields that are allowed to be updated.
-
-    Args:
-        investigation: The investigation parameters dictionary.
-
-    Returns:
-        Dictionary formatted for the Splunk investigations update API.
-    """
-    res = {}
-
-    for field in UPDATABLE_FIELDS:
-        if field in investigation and investigation[field] is not None:
-            value = investigation[field]
-
-            # Handle status conversion
-            if field == "status":
-                value = STATUS_TO_API.get(value, value)
-
-            # Handle disposition conversion
-            if field == "disposition":
-                value = DISPOSITION_TO_API.get(value.lower(), value)
-
-            # Handle sensitivity conversion
-            if field == "sensitivity":
-                value = SENSITIVITY_TO_API.get(value.lower(), value)
-
-            res[field] = value
 
     return res

--- a/plugins/module_utils/splunk_utils.py
+++ b/plugins/module_utils/splunk_utils.py
@@ -14,6 +14,34 @@ making them safe to import in unit tests without triggering Ansible imports.
 DEFAULT_API_NAMESPACE = "servicesNS"
 DEFAULT_API_USER = "nobody"
 DEFAULT_API_APP = "missioncontrol"
+DEFAULT_API_APP_SECURITY_SUITE = "SplunkEnterpriseSecuritySuite"
+
+# Disposition mapping: module value -> API value (shared by finding and investigation)
+DISPOSITION_TO_API = {
+    "unassigned": "disposition:0",
+    "true_positive": "disposition:1",
+    "benign_positive": "disposition:2",
+    "false_positive": "disposition:3",
+    "false_positive_inaccurate_data": "disposition:4",
+    "other": "disposition:5",
+    "undetermined": "disposition:6",
+}
+
+# Disposition mapping: API value -> module value
+DISPOSITION_FROM_API = {v: k for k, v in DISPOSITION_TO_API.items()}
+
+# Status mapping: module value -> API value (shared by finding and investigation)
+STATUS_TO_API = {
+    "unassigned": "0",
+    "new": "1",
+    "in_progress": "2",
+    "pending": "3",
+    "resolved": "4",
+    "closed": "5",
+}
+
+# Status mapping: API value -> module value
+STATUS_FROM_API = {v: k for k, v in STATUS_TO_API.items()}
 
 
 def remove_get_keys_from_payload_dict(payload_dict, remove_key_list):

--- a/plugins/modules/splunk_finding_info.py
+++ b/plugins/modules/splunk_finding_info.py
@@ -57,6 +57,13 @@ options:
       - Applies when querying by C(title) or all findings.
     required: false
     type: str
+  limit:
+    description:
+      - Maximum number of findings to return.
+      - If not specified, all matching findings are returned.
+      - Use this to limit large result sets.
+    required: false
+    type: int
   api_namespace:
     description:
       - The namespace portion of the Splunk API path.
@@ -122,6 +129,12 @@ EXAMPLES = """
   splunk.es.splunk_finding_info:
     earliest: "-30d"
   register: all_findings
+
+- name: Query findings with a limit on results
+  splunk.es.splunk_finding_info:
+    earliest: "-7d"
+    limit: 100
+  register: limited_findings
 
 - name: Query findings from a specific time range (ISO 8601)
   splunk.es.splunk_finding_info:

--- a/plugins/modules/splunk_investigation_info.py
+++ b/plugins/modules/splunk_investigation_info.py
@@ -48,6 +48,13 @@ options:
       - If not provided, no maximum time filter is applied.
     required: false
     type: str
+  limit:
+    description:
+      - Maximum number of investigations to return.
+      - If not specified, all matching investigations are returned.
+      - Use this to limit large result sets.
+    required: false
+    type: int
   api_namespace:
     description:
       - The namespace portion of the Splunk API path.
@@ -113,6 +120,12 @@ EXAMPLES = """
   splunk.es.splunk_investigation_info:
     create_time_min: "-30d"
   register: all_investigations
+
+- name: Query investigations with a limit on results
+  splunk.es.splunk_investigation_info:
+    create_time_min: "-7d"
+    limit: 50
+  register: limited_investigations
 
 - name: Query investigations from a specific time range (ISO 8601)
   splunk.es.splunk_investigation_info:

--- a/plugins/modules/splunk_response_plan_info.py
+++ b/plugins/modules/splunk_response_plan_info.py
@@ -24,6 +24,13 @@ options:
       - If not specified, returns all response plans.
     required: false
     type: str
+  limit:
+    description:
+      - Maximum number of response plans to return.
+      - If not specified, returns all matching response plans.
+      - Useful for limiting results when querying large numbers of response plans.
+    required: false
+    type: int
   api_namespace:
     description:
       - The namespace portion of the Splunk API path.

--- a/tests/integration/targets/splunk_finding/tests/tests.yaml
+++ b/tests/integration/targets/splunk_finding/tests/tests.yaml
@@ -232,3 +232,16 @@
           - info_resolved_result['findings'] | length == 1
           - info_resolved_result['findings'][0]['status'] == "resolved"
           - info_resolved_result['findings'][0]['disposition'] == "true_positive"
+
+    # splunk_finding_info tests - Query with limit parameter
+    - name: Query findings with limit=1
+      register: info_limit_one_result
+      splunk.es.splunk_finding_info:
+        earliest: "-1h"
+        limit: 1
+
+    - name: Assert limit=1 returns exactly one finding
+      assert:
+        that:
+          - info_limit_one_result['changed'] == false
+          - info_limit_one_result['findings'] | length == 1

--- a/tests/integration/targets/splunk_investigation/tests/tests.yaml
+++ b/tests/integration/targets/splunk_investigation/tests/tests.yaml
@@ -287,3 +287,16 @@
           - info_not_found_result['changed'] == false
           - info_not_found_result['failed'] is not defined or info_not_found_result['failed'] == false
           - info_not_found_result['investigations'] | length == 0
+
+    # splunk_investigation_info tests - Query with limit parameter
+    - name: Query investigations with limit=1
+      register: info_limit_one_result
+      splunk.es.splunk_investigation_info:
+        create_time_min: "-1h"
+        limit: 1
+
+    - name: Assert limit=1 returns exactly one investigation
+      assert:
+        that:
+          - info_limit_one_result['changed'] == false
+          - info_limit_one_result['investigations'] | length == 1

--- a/tests/integration/targets/splunk_response_plan/tests/tests.yaml
+++ b/tests/integration/targets/splunk_response_plan/tests/tests.yaml
@@ -329,6 +329,18 @@
           - info_all['response_plans'] | selectattr('name', 'equalto', 'Ansible Complex Response Plan') | list | length == 1
           - info_all['response_plans'] | selectattr('name', 'equalto', 'Ansible Draft Response Plan') | list | length == 1
 
+    # splunk_response_plan_info tests - Query with limit parameter
+    - name: Query response plans with limit=1
+      register: info_limit_one_result
+      splunk.es.splunk_response_plan_info:
+        limit: 1
+
+    - name: Assert limit=1 returns exactly one response plan
+      assert:
+        that:
+          - info_limit_one_result['changed'] == false
+          - info_limit_one_result['response_plans'] | length == 1
+
     - name: Delete response plan (CHECK MODE)
       check_mode: true
       register: delete_check_result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Added limit query param support for info modules - Lets the user an option to choose how many objects will be returned.
* Refactored the util files to have only shared functions and variables (shared between info and main module).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
splunk_response_plan
splunk_finding
splnuk_investigation
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
