### PR TITLE
Add actor check to prevent duplicate integration run after pre-commit bot creates a commit

### DIFF
--- a/.github/workflows/network_integration.yml
+++ b/.github/workflows/network_integration.yml
@@ -2,7 +2,7 @@
 name: "Network Integration Tests"
 
 concurrency:
-  group: integration-${{ github.head_ref || github.run_id }}
+  group: ${{ github.actor == 'pre-commit-ci[bot]' && format('integration-bot-{0}', github.run_id) || 'integration' }}
   cancel-in-progress: true
 
 on:
@@ -21,8 +21,18 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  check-actor:
+    name: Check Actor
+    if: github.actor != 'pre-commit-ci[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Actor ${{ github.actor }} is allowed to run integration tests"
   safe-to-test:
+    needs:
+      - check-actor
     if: >-
+      always() &&
+      needs.check-actor.result == 'success' &&
       github.event_name == 'pull_request_target' &&
       (github.event.label.name == 'safe to test' ||
       github.event.action != 'labeled')
@@ -35,9 +45,11 @@ jobs:
     environment:
       name: ${{ github.event_name == 'schedule' && 'eco-splunk-daily' || 'eco-splunk-protected' }}
     needs:
+      - check-actor
       - safe-to-test
     if: >-
       always() &&
+      needs.check-actor.result == 'success' &&
       (needs.safe-to-test.result == 'success' || needs.safe-to-test.result == 'skipped')
     steps:
       - name: Checkout repository


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently after pre-commit bot creates a commit on top of our commit another integration test runs. After support environment to block runs without permission, it creates a situation in which 2 integration tests are triggered and one is pending.

This approach should skip the integration test run triggered by the pre-commit and only apply the one by the user.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
