### PR TITLE
Fix finding query by ref_id time boundary precision issue

### DIFF
--- a/changelogs/fragments/fix-finding-earliest-time-boundary.yaml
+++ b/changelogs/fragments/fix-finding-earliest-time-boundary.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - splunk_finding, splunk_finding_info - Fix query by ref_id failing to find findings due to
+    sub-second time precision mismatch. The ``earliest`` time extracted from the ref_id now
+    includes a 1-second buffer to ensure the finding falls within the search window.

--- a/plugins/action/splunk_finding.py
+++ b/plugins/action/splunk_finding.py
@@ -34,6 +34,7 @@ from ansible_collections.splunk.es.plugins.module_utils.finding import (
     FINDING_KEY_TRANSFORM,
     build_finding_api_path,
     extract_notable_time,
+    get_earliest_from_ref_id,
     map_finding_from_api,
 )
 from ansible_collections.splunk.es.plugins.module_utils.splunk import (
@@ -280,13 +281,11 @@ class ActionModule(ActionBase):
         """
         display.vv(f"splunk_finding: getting finding by ref_id: {ref_id}")
 
-        # Extract timestamp from ref_id to set earliest time filter
-        # This allows querying findings older than 24 hours
         query_params = {}
-        notable_time = extract_notable_time(ref_id)
-        if notable_time:
-            query_params["earliest"] = notable_time
-            display.vvv(f"splunk_finding: using earliest={notable_time} from ref_id")
+        earliest = get_earliest_from_ref_id(ref_id)
+        if earliest:
+            query_params["earliest"] = earliest
+            display.vvv(f"splunk_finding: using earliest={earliest} from ref_id")
 
         query_dict = conn_request.get_by_path(
             f"{self.api_object}/{quote(ref_id)}",

--- a/plugins/action/splunk_finding_info.py
+++ b/plugins/action/splunk_finding_info.py
@@ -16,7 +16,7 @@ from ansible.utils.display import Display
 from ansible_collections.splunk.es.plugins.module_utils.finding import (
     FINDING_KEY_TRANSFORM,
     build_finding_api_path,
-    extract_notable_time,
+    get_earliest_from_ref_id,
     map_finding_from_api,
 )
 from ansible_collections.splunk.es.plugins.module_utils.splunk import (
@@ -104,12 +104,11 @@ class ActionModule(ActionBase):
         """
         display.vv(f"splunk_finding_info: getting finding by ref_id: {ref_id}")
 
-        # Extract timestamp from ref_id to set earliest time filter
         query_params = {}
-        notable_time = extract_notable_time(ref_id)
-        if notable_time:
-            query_params["earliest"] = notable_time
-            display.vvv(f"splunk_finding_info: using earliest={notable_time} from ref_id")
+        earliest = get_earliest_from_ref_id(ref_id)
+        if earliest:
+            query_params["earliest"] = earliest
+            display.vvv(f"splunk_finding_info: using earliest={earliest} from ref_id")
 
         query_dict = conn_request.get_by_path(
             f"{self.api_object}/{quote(ref_id)}",

--- a/plugins/module_utils/finding.py
+++ b/plugins/module_utils/finding.py
@@ -74,6 +74,31 @@ def extract_notable_time(ref_id: str) -> Optional[str]:
     return None
 
 
+# Buffer in seconds to subtract from notable_time when used as 'earliest'
+# in time-range queries. The Splunk API may treat 'earliest' as exclusive
+# or the finding's _time may have sub-second precision slightly before the
+# integer epoch in the ref_id, so a small buffer avoids missing the finding.
+_EARLIEST_BUFFER_SECONDS = 1
+
+
+def get_earliest_from_ref_id(ref_id: str) -> Optional[str]:
+    """Get a buffered earliest time suitable for Splunk time-range queries.
+
+    Extracts the notable time from the ref_id and subtracts a small buffer
+    to ensure the finding falls within the query's time range.
+
+    Args:
+        ref_id: The finding reference ID.
+
+    Returns:
+        The buffered earliest time as a string, or None if extraction fails.
+    """
+    notable_time = extract_notable_time(ref_id)
+    if notable_time is None:
+        return None
+    return str(int(notable_time) - _EARLIEST_BUFFER_SECONDS)
+
+
 def map_finding_from_api(
     config: dict[str, Any],
     key_transform: dict[str, str] = None,

--- a/tests/unit/plugins/action/test_es_finding_info.py
+++ b/tests/unit/plugins/action/test_es_finding_info.py
@@ -460,8 +460,8 @@ class TestSplunkFindingInfo:
         assert result["changed"] is False
         assert result.get("failed") is not True
         assert len(captured_params) > 0
-        # Time should be extracted from ref_id, not from user-provided params
-        assert captured_params[0].get("earliest") == "1768225865"
+        # Time should be extracted from ref_id (with 1s buffer), not from user-provided params
+        assert captured_params[0].get("earliest") == "1768225864"
         # latest should not be passed when querying by ref_id
         assert captured_params[0].get("latest") is None
 

--- a/tests/unit/plugins/module_utils/test_finding_utils.py
+++ b/tests/unit/plugins/module_utils/test_finding_utils.py
@@ -35,6 +35,7 @@ from ansible_collections.splunk.es.plugins.module_utils.finding import (
     FINDING_KEY_TRANSFORM,
     build_finding_api_path,
     extract_notable_time,
+    get_earliest_from_ref_id,
     map_finding_from_api,
 )
 from ansible_collections.splunk.es.plugins.module_utils.splunk_utils import (
@@ -201,6 +202,55 @@ class TestExtractNotableTime:
         result = extract_notable_time(ref_id)
 
         assert result is None
+
+
+class TestGetEarliestFromRefId:
+    """Tests for the get_earliest_from_ref_id function.
+
+    This function extracts the notable time from a ref_id and applies a 1-second
+    buffer so the resulting 'earliest' value is guaranteed to include the finding
+    in Splunk time-range queries.
+    """
+
+    def test_get_earliest_from_ref_id_valid(self):
+        """Test that a valid ref_id returns the timestamp minus 1 second."""
+        ref_id = "2008e99d-af14-4fec-89da-b9b17a81820a@@notable@@time1768225865"
+        result = get_earliest_from_ref_id(ref_id)
+
+        assert result == "1768225864"
+
+    def test_get_earliest_from_ref_id_different_timestamp(self):
+        """Test with a different timestamp value."""
+        ref_id = "abc123@@notable@@time1000000000"
+        result = get_earliest_from_ref_id(ref_id)
+
+        assert result == "999999999"
+
+    def test_get_earliest_from_ref_id_empty_string(self):
+        """Test that empty ref_id returns None."""
+        result = get_earliest_from_ref_id("")
+
+        assert result is None
+
+    def test_get_earliest_from_ref_id_none(self):
+        """Test that None ref_id returns None."""
+        result = get_earliest_from_ref_id(None)
+
+        assert result is None
+
+    def test_get_earliest_from_ref_id_no_time(self):
+        """Test that ref_id without time component returns None."""
+        ref_id = "just-a-uuid-without-time"
+        result = get_earliest_from_ref_id(ref_id)
+
+        assert result is None
+
+    def test_get_earliest_from_ref_id_timestamp_1(self):
+        """Test boundary: timestamp of 1 returns '0'."""
+        ref_id = "abc@@notable@@time1"
+        result = get_earliest_from_ref_id(ref_id)
+
+        assert result == "0"
 
 
 class TestMapFindingFromApi:


### PR DESCRIPTION
#### SUMMARY
- Fix `splunk_finding` and `splunk_finding_info` failing to find findings when querying by `ref_id`.
- The `earliest` time parameter extracted from the ref_id used the exact integer timestamp, but the finding's internal `_time` may have sub-second precision slightly before that integer, causing it to fall outside the query window.
- Introduced `get_earliest_from_ref_id()` utility that subtracts a 1-second buffer from the extracted timestamp, ensuring the finding is always within the search range.

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- plugins/module_utils/finding.py
- plugins/action/splunk_finding.py
- plugins/action/splunk_finding_info.py
- tests/unit/plugins/module_utils/test_finding_utils.py
- tests/unit/plugins/action/test_es_finding_info.py
- changelogs/fragments/fix-finding-earliest-time-boundary.yaml

#### ADDITIONAL INFORMATION
- Added unit tests for the new `get_earliest_from_ref_id()` function covering valid ref_ids, edge cases (None, empty, no time component), and boundary values.
- Updated existing unit test assertion to expect the buffered earliest value.
- Both `splunk_finding` (create/update) and `splunk_finding_info` (query) action plugins are updated to use the new buffered utility.
- Changelog fragment added under `bugfixes`.