### PR TITLE
Add ansible-core version matrix to integration tests

### DIFF
--- a/.github/workflows/network_integration.yml
+++ b/.github/workflows/network_integration.yml
@@ -18,7 +18,7 @@ on:
       - "tests/integration/**"
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 1 */3 * *"
 
 jobs:
   check-actor:
@@ -38,10 +38,9 @@ jobs:
       github.event.action != 'labeled')
     uses: ansible-network/github_actions/.github/workflows/safe-to-test.yml@main
 
-  network-integration:
-    name: Network Integration Tests
-    runs-on: [self-hosted]
-    # Protect the workflow from running on PRs without approval
+  approve:
+    name: Approve Integration
+    runs-on: ubuntu-latest
     environment:
       name: ${{ github.event_name == 'schedule' && 'eco-splunk-daily' || 'eco-splunk-protected' }}
     needs:
@@ -52,19 +51,39 @@ jobs:
       needs.check-actor.result == 'success' &&
       (needs.safe-to-test.result == 'success' || needs.safe-to-test.result == 'skipped')
     steps:
+      - run: echo "Deployment approved"
+
+  network-integration:
+    name: "Integration (${{ matrix.ansible_version }})"
+    runs-on: [self-hosted]
+    needs:
+      - approve
+    if: always() && needs.approve.result == 'success'
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        ansible_version:
+          - stable-2.16
+          - stable-2.17
+          - stable-2.18
+          - stable-2.19
+          - stable-2.20
+          - stable-2.21
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           path: ansible_collections/splunk/es
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install ansible-core
+      - name: Install ansible-core (${{ matrix.ansible_version }})
         working-directory: ansible_collections/splunk/es
         run: |
           rm -rf ~/venv-runner
           python -m venv ~/venv-runner
           source ~/venv-runner/bin/activate
-          pip install -r requirements.txt
+          pip install "git+https://github.com/ansible/ansible.git@${{ matrix.ansible_version }}"
 
       - name: Install collection dependencies
         run: |

--- a/changelogs/fragments/add-integration-test-matrix.yaml
+++ b/changelogs/fragments/add-integration-test-matrix.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - ci - Add ansible-core version matrix (stable-2.16 through stable-2.21) to the network
+    integration test workflow, aligning with the ITSI pattern. Lower minimum supported
+    ansible-core version to 2.16.0.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-core>=2.17.0
+ansible-core>=2.16.0


### PR DESCRIPTION
#### SUMMARY
- Align the network integration workflow with the ITSI pattern to test across all current stable ansible-core versions (2.16 through 2.21)
- Add an `approve` gate job between safety checks and integration test execution
- Add matrix strategy with `fail-fast: false` and `max-parallel: 1` to run integration tests sequentially across each stable branch
- Install ansible-core directly from git per matrix version instead of from `requirements.txt`
- Update schedule from daily to every 3 days (`0 1 */3 * *`)
- Lower minimum ansible-core version in `requirements.txt` from 2.17.0 to 2.16.0

#### ISSUE TYPE
- Feature Pull Request

#### COMPONENT NAME
- `.github/workflows/network_integration.yml`
- `requirements.txt`

#### ADDITIONAL INFORMATION
- No functional changes to plugin or module code
- The workflow structure now matches the splunk.itsi integration test pattern with the three-job chain: `check-actor` + `safe-to-test` → `approve` → `network-integration`
- Runner label remains `[self-hosted]` and environment names remain `eco-splunk-daily` / `eco-splunk-protected`