### PR TITLE
Fix data_inputs_monitor missing fail_json for ansible-core 2.16 compatibility

### DIFF
--- a/plugins/action/splunk_data_inputs_monitor.py
+++ b/plugins/action/splunk_data_inputs_monitor.py
@@ -21,6 +21,7 @@
 The module file for data_inputs_monitor
 """
 
+from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible.plugins.action import ActionBase
@@ -66,6 +67,14 @@ class ActionModule(ActionBase):
             "time-before-close": "time_before_close",  # not returned
             "whitelist": "whitelist",
         }
+
+    def fail_json(self, msg):
+        """Replace the AnsibleModule fail_json here for stable-2.16 compatibility
+        :param msg: The message for the failure
+        :type msg: str
+        """
+        msg = msg.replace("(basic.py)", self._task.action)
+        raise AnsibleActionFail(msg)
 
     def map_params_to_object(self, config):
         res = {}

--- a/tests/unit/plugins/action/test_es_data_inputs_monitors.py
+++ b/tests/unit/plugins/action/test_es_data_inputs_monitors.py
@@ -200,8 +200,12 @@ class TestSplunkEsDataInputsMonitorRules:
         def get_by_path(self, path):
             return RESPONSE_PAYLOAD
 
+        def delete_by_path(self, path):
+            return {}
+
         monkeypatch.setattr(SplunkRequest, "create_update", create_update)
         monkeypatch.setattr(SplunkRequest, "get_by_path", get_by_path)
+        monkeypatch.setattr(SplunkRequest, "delete_by_path", delete_by_path)
 
         self._plugin._task.args = {
             "state": "replaced",
@@ -312,8 +316,12 @@ class TestSplunkEsDataInputsMonitorRules:
         def get_by_path(self, path):
             return RESPONSE_PAYLOAD
 
+        def delete_by_path(self, path):
+            return {}
+
         monkeypatch.setattr(SplunkRequest, "create_update", create_update)
         monkeypatch.setattr(SplunkRequest, "get_by_path", get_by_path)
+        monkeypatch.setattr(SplunkRequest, "delete_by_path", delete_by_path)
 
         self._plugin._task.args = {
             "state": "deleted",


### PR DESCRIPTION
#### SUMMARY
- The `splunk_data_inputs_monitor` action plugin was missing a `fail_json` method, causing `AttributeError: 'ActionModule' object has no attribute 'fail_json'` on ansible-core 2.16 where `ActionBase` does not provide this method.
- Added the `fail_json` method and `AnsibleActionFail` import, matching the pattern already used by all other action plugins in the collection (e.g. `splunk_data_inputs_network`).

#### ISSUE TYPE
- Bug Fix Pull Request

#### COMPONENT NAME
- `plugins/action/splunk_data_inputs_monitor.py`

#### ADDITIONAL INFORMATION
- This was the only action plugin in the collection missing `fail_json`; all 16 others already define it.
- The method is called by `SplunkRequest._httpapi_error_handle()` when API errors occur.
- On ansible-core 2.17+ `ActionBase` gained a built-in `fail_json`, masking the omission. On 2.16 it does not exist, causing the crash.