### PR TITLE
Remove ansible.netcommon collection dependency

### DIFF
--- a/.github/workflows/network_integration.yml
+++ b/.github/workflows/network_integration.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install collection dependencies
         run: |
           source ~/venv-runner/bin/activate
-          ansible-galaxy collection install ansible.netcommon ansible.utils -p ./ansible_collections
+          ansible-galaxy collection install ansible.utils -p ./ansible_collections
 
       - name: Generate inventory file
         working-directory: ansible_collections/splunk/es

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,6 @@ jobs:
       sonar_scanner_java_opts: "-Xss2m"
       galaxy_dependencies: |
         git+https://github.com/ansible-collections/ansible.utils.git
-        git+https://github.com/ansible-collections/ansible.netcommon.git
     secrets:
       SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
   changelog:

--- a/changelogs/fragments/remove-netcommon-dependency.yaml
+++ b/changelogs/fragments/remove-netcommon-dependency.yaml
@@ -1,0 +1,4 @@
+major_changes:
+  - Remove dependency on the ``ansible.netcommon`` collection. Utility functions
+    (``remove_empties``, ``dict_diff``, ``dict_merge``) are now bundled locally,
+    and the httpapi plugin inherits directly from ansible-core's ``HttpApiBase``.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,8 +5,7 @@ authors:
   - Ansible Ecosystem Engineering team
   - Ron Gershburg <rgershbu@redhat.com>
   - Shahar Golshani <sgolshan@redhat.com>
-dependencies:
-  ansible.netcommon: ">=6.0.0"
+dependencies: {}
 description: Ansible Security Collection for Splunk Enterprise Security SIEM
 license_file: LICENSE
 tags: ["security", "splunk"]

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,8 @@ authors:
   - Ansible Ecosystem Engineering team
   - Ron Gershburg <rgershbu@redhat.com>
   - Shahar Golshani <sgolshan@redhat.com>
-dependencies: {}
+dependencies:
+  ansible.utils: ">=2.0.0"
 description: Ansible Security Collection for Splunk Enterprise Security SIEM
 license_file: LICENSE
 tags: ["security", "splunk"]

--- a/plugins/action/splunk_adaptive_response_notable_events.py
+++ b/plugins/action/splunk_adaptive_response_notable_events.py
@@ -27,8 +27,8 @@ from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.plugins.action import ActionBase
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 from ansible_collections.splunk.es.plugins.module_utils.splunk import (
     SplunkRequest,
     check_argspec,

--- a/plugins/action/splunk_correlation_searches.py
+++ b/plugins/action/splunk_correlation_searches.py
@@ -27,8 +27,8 @@ from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.plugins.action import ActionBase
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 from ansible_collections.splunk.es.plugins.module_utils.splunk import (
     SplunkRequest,
     check_argspec,

--- a/plugins/action/splunk_data_inputs_monitor.py
+++ b/plugins/action/splunk_data_inputs_monitor.py
@@ -25,8 +25,8 @@ from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible.plugins.action import ActionBase
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 from ansible_collections.splunk.es.plugins.module_utils.splunk import (
     SplunkRequest,
     check_argspec,

--- a/plugins/action/splunk_data_inputs_network.py
+++ b/plugins/action/splunk_data_inputs_network.py
@@ -25,8 +25,8 @@ from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import quote_plus
 from ansible.plugins.action import ActionBase
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 from ansible_collections.splunk.es.plugins.module_utils.splunk import (
     SplunkRequest,
     check_argspec,

--- a/plugins/action/splunk_finding.py
+++ b/plugins/action/splunk_finding.py
@@ -28,8 +28,8 @@ from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 from ansible_collections.splunk.es.plugins.module_utils.finding import (
     FINDING_KEY_TRANSFORM,
     build_finding_api_path,

--- a/plugins/action/splunk_investigation.py
+++ b/plugins/action/splunk_investigation.py
@@ -27,8 +27,8 @@ from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 from ansible_collections.splunk.es.plugins.module_utils.investigation import (
     build_investigation_api_path,
     map_investigation_from_api,

--- a/plugins/httpapi/splunk.py
+++ b/plugins/httpapi/splunk.py
@@ -18,7 +18,7 @@ from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.basic import to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible_collections.ansible.netcommon.plugins.plugin_utils.httpapi_base import HttpApiBase
+from ansible.plugins.httpapi import HttpApiBase
 
 
 BASE_HEADERS = {"Content-Type": "application/json"}

--- a/plugins/module_utils/dict_utils.py
+++ b/plugins/module_utils/dict_utils.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Dictionary utility functions for Ansible Splunk ES collection.
+
+These functions were originally provided by ansible.netcommon's
+``network.common.utils`` module and are inlined here to remove
+that collection dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from itertools import chain
+
+
+def sort_list(val):
+    """Sort a value if it is a list, otherwise return as-is.
+
+    Args:
+        val: Any value. If it is a list of dicts, each dict is
+            converted to a sorted-tuple representation for comparison.
+
+    Returns:
+        A sorted copy of the list, or the original value unchanged.
+    """
+    if isinstance(val, list):
+        if all(isinstance(x, dict) for x in val):
+            return sorted(val, key=lambda x: sorted(x.items()))
+        return sorted(val)
+    return val
+
+
+def remove_empties(cfg_dict: dict) -> dict:
+    """Recursively remove keys with empty/None values from a dictionary.
+
+    Args:
+        cfg_dict: A dictionary to clean.
+
+    Returns:
+        A new dictionary with all None, empty-list, empty-dict,
+        empty-tuple, and empty-string values removed.
+    """
+    final_cfg: dict = {}
+    if not cfg_dict:
+        return final_cfg
+
+    for key, val in cfg_dict.items():
+        dct = None
+        if isinstance(val, dict):
+            child_val = remove_empties(val)
+            if child_val:
+                dct = {key: child_val}
+        elif isinstance(val, list) and val and all(isinstance(x, dict) for x in val):
+            child_val = [remove_empties(x) for x in val]
+            if child_val:
+                dct = {key: child_val}
+        elif val not in [None, [], {}, (), ""]:
+            dct = {key: val}
+        if dct:
+            final_cfg.update(dct)
+    return final_cfg
+
+
+def dict_diff(base: dict, comparable: dict) -> dict:
+    """Compute the difference between two dictionaries.
+
+    For scalar values the key reflects the updated value from *comparable*.
+    Keys absent from *comparable* are ignored.  Lists are replaced wholly.
+    Nested dicts are compared recursively.
+
+    Args:
+        base: The reference dictionary.
+        comparable: The dictionary to compare against *base*.
+
+    Returns:
+        A new dictionary containing only the differences.
+
+    Raises:
+        AssertionError: If *base* or *comparable* is not a dict
+            (None is accepted for *comparable*).
+    """
+    if not isinstance(base, dict):
+        raise AssertionError("`base` must be of type <dict>")
+    if not isinstance(comparable, dict):
+        if comparable is None:
+            comparable = {}
+        else:
+            raise AssertionError("`comparable` must be of type <dict>")
+
+    updates: dict = {}
+
+    for key, value in base.items():
+        if isinstance(value, dict):
+            item = comparable.get(key)
+            if item is not None:
+                sub_diff = dict_diff(value, comparable[key])
+                if sub_diff:
+                    updates[key] = sub_diff
+        else:
+            comparable_value = comparable.get(key)
+            if comparable_value is not None:
+                if sort_list(base[key]) != sort_list(comparable_value):
+                    updates[key] = comparable_value
+
+    for key in set(comparable.keys()).difference(base.keys()):
+        updates[key] = comparable.get(key)
+
+    return updates
+
+
+def dict_merge(base: dict, other: dict) -> dict:
+    """Deep-merge two dictionaries, preferring values from *other*.
+
+    When both keys exist the value is taken from *other*.  Lists are
+    combined with duplicates removed.  Nested dicts are merged recursively.
+
+    Args:
+        base: The base dictionary.
+        other: The dictionary to merge into *base*.
+
+    Returns:
+        A new combined dictionary.
+
+    Raises:
+        AssertionError: If either argument is not a dict.
+    """
+    if not isinstance(base, dict):
+        raise AssertionError("`base` must be of type <dict>")
+    if not isinstance(other, dict):
+        raise AssertionError("`other` must be of type <dict>")
+
+    combined: dict = {}
+
+    for key, value in deepcopy(base).items():
+        if isinstance(value, dict):
+            if key in other:
+                item = other.get(key)
+                if item is not None:
+                    if isinstance(other[key], Mapping):
+                        combined[key] = dict_merge(value, other[key])
+                    else:
+                        combined[key] = other[key]
+                else:
+                    combined[key] = item
+            else:
+                combined[key] = value
+        elif isinstance(value, list):
+            if key in other:
+                item = other.get(key)
+                if item is not None:
+                    try:
+                        combined[key] = list(set(chain(value, item)))
+                    except TypeError:
+                        value.extend([i for i in item if i not in value])
+                        combined[key] = value
+                else:
+                    combined[key] = item
+            else:
+                combined[key] = value
+        else:
+            if key in other:
+                other_value = other.get(key)
+                if other_value is not None:
+                    if sort_list(base[key]) != sort_list(other_value):
+                        combined[key] = other_value
+                    else:
+                        combined[key] = value
+                else:
+                    combined[key] = other_value
+            else:
+                combined[key] = value
+
+    for key in set(other.keys()).difference(base.keys()):
+        combined[key] = other.get(key)
+
+    return combined

--- a/plugins/module_utils/splunk.py
+++ b/plugins/module_utils/splunk.py
@@ -15,10 +15,11 @@ except ImportError:
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError as AnsibleConnectionError
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
     AnsibleArgSpecValidator,
 )
+
+from ansible_collections.splunk.es.plugins.module_utils import dict_utils as utils
 
 
 def check_argspec(action_module, result, documentation):

--- a/tests/integration/targets/splunk_adaptive_response_notable_events/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_adaptive_response_notable_events/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_correlation_search_info/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_correlation_search_info/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_correlation_searches/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_correlation_searches/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_data_inputs_monitor/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_data_inputs_monitor/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_data_inputs_network/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_data_inputs_network/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_finding/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_finding/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_finding/tests/tests.yaml
+++ b/tests/integration/targets/splunk_finding/tests/tests.yaml
@@ -43,13 +43,12 @@
           - create_result['finding']['after']['title'] == create_finding['after']['title']
           - create_result['finding']['after']['ref_id'] is defined
 
-    - name: Wait for Splunk to index the finding
-      ansible.builtin.pause:
-        seconds: 10
-
-    # Query by ref_id
+    # Query by ref_id -- retry to allow Splunk indexing lag
     - name: Query finding by ref_id (time extracted from ref_id automatically)
       register: info_by_ref_result
+      until: info_by_ref_result['findings'] | length == 1
+      retries: 6
+      delay: 10
       splunk.es.splunk_finding_info:
         ref_id: "{{ create_result['finding']['after']['ref_id'] }}"
 
@@ -149,9 +148,14 @@
           - custom_result['finding']['after']['security_domain'] == create_finding_custom['after']['security_domain']
           - custom_result['finding']['after']['entity_type'] == create_finding_custom['after']['entity_type']
 
-    - name: Wait for Splunk to index the custom finding
-      ansible.builtin.pause:
-        seconds: 10
+    # Wait for custom finding to be indexed before updating
+    - name: Wait for custom finding to be queryable
+      register: custom_indexed
+      until: custom_indexed['findings'] | length == 1
+      retries: 6
+      delay: 10
+      splunk.es.splunk_finding_info:
+        ref_id: "{{ custom_result['finding']['after']['ref_id'] }}"
 
     - name: Update finding to resolved status
       register: resolve_result

--- a/tests/integration/targets/splunk_investigation/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_investigation/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_investigation_type/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_investigation_type/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_notes/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_notes/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_response_plan/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_response_plan/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/splunk_response_plan_execution/tasks/cli.yaml
+++ b/tests/integration/targets/splunk_response_plan_execution/tasks/cli.yaml
@@ -9,10 +9,10 @@
   ansible.builtin.set_fact:
     test_items: "{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: Run test case (connection=ansible.netcommon.httpapi)
+- name: Run test case (connection=ansible.builtin.httpapi)
   ansible.builtin.include_tasks: "{{ test_case_to_run }}"
   vars:
-    ansible_connection: ansible.netcommon.httpapi
+    ansible_connection: ansible.builtin.httpapi
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run


### PR DESCRIPTION
#### SUMMARY
- Remove the `ansible.netcommon` collection as a runtime dependency
- Inline the three dict utility functions (`remove_empties`, `dict_diff`, `dict_merge`) from netcommon's `network.common.utils` into a new local `plugins/module_utils/dict_utils.py` module
- Switch the httpapi plugin (`plugins/httpapi/splunk.py`) to inherit directly from ansible-core's built-in `HttpApiBase` instead of netcommon's wrapper
- Update all 11 integration test connection references from `ansible.netcommon.httpapi` to `ansible.builtin.httpapi`
- Replace brittle fixed `pause: 10` in finding integration tests with `until/retries/delay` retry loops to handle Splunk indexing lag
- Remove netcommon from `galaxy.yml` dependencies and CI workflow install steps

#### ISSUE TYPE
- Refactoring Pull Request

#### COMPONENT NAME
- `plugins/module_utils/dict_utils.py` (new)
- `plugins/module_utils/splunk.py`
- `plugins/httpapi/splunk.py`
- `plugins/action/splunk_adaptive_response_notable_events.py`
- `plugins/action/splunk_correlation_searches.py`
- `plugins/action/splunk_data_inputs_monitor.py`
- `plugins/action/splunk_data_inputs_network.py`
- `plugins/action/splunk_finding.py`
- `plugins/action/splunk_investigation.py`
- `galaxy.yml`
- `.github/workflows/network_integration.yml`
- `.github/workflows/tests.yml`
- `tests/integration/targets/*/tasks/cli.yaml` (11 files)
- `tests/integration/targets/splunk_finding/tests/tests.yaml`

#### ADDITIONAL INFORMATION
- The inlined utility functions (`remove_empties`, `dict_diff`, `dict_merge`, `sort_list`) are pure Python with no Ansible imports, making them easy to unit test
- The `ansible.utils` dependency is retained (used for `AnsibleArgSpecValidator`)
- Netcommon's `HttpApiBase` was a thin wrapper around ansible-core's base class; the httpapi plugin only used `send_request` and internal helpers, none of the netcommon-added methods
- Finding integration tests were flaky due to Splunk indexing lag; replaced fixed pauses with retry loops (up to 6 retries, 10s delay)